### PR TITLE
Added a special case for OperationCanceledException in the ApiErrorFactory. Now they should be logged as warns instead of errors.

### DIFF
--- a/src/aspnetcore-exceptionhandler/ExceptionHandling/ApiErrorFactory.cs
+++ b/src/aspnetcore-exceptionhandler/ExceptionHandling/ApiErrorFactory.cs
@@ -28,12 +28,12 @@ namespace Frogvall.AspNetCore.ExceptionHandling.ExceptionHandling
 
             switch (ex)
             {
-                case BaseApiException _:
+                case BaseApiException baseApiException:
                     try
                     {
-                        if (mapper.Options.RespondWithDeveloperContext) developerContext = (ex as BaseApiException)?.DeveloperContext;
-                        errorCode = mapper.GetErrorCode(ex as BaseApiException);
-                        statusCode = mapper.GetExceptionHandlerReturnCode(ex as BaseApiException);
+                        if (mapper.Options.RespondWithDeveloperContext) developerContext = baseApiException.DeveloperContext;
+                        errorCode = mapper.GetErrorCode(baseApiException);
+                        statusCode = mapper.GetExceptionHandlerReturnCode(baseApiException);
                         context.Response.StatusCode = (int)statusCode;
                         logger.LogInformation(ex,
                             "Mapped BaseApiException of type {exceptionType} caught by ApiExceptionHandler. Will return with {statusCodeInt} {statusCodeString}. Unexpected: {unexpected}",
@@ -45,12 +45,20 @@ namespace Frogvall.AspNetCore.ExceptionHandling.ExceptionHandling
                     }
 
                     break;
-                case ApiException _:
+                case ApiException apiException:
                     errorCode = -2;
-                    statusCode = (ex as ApiException).StatusCode;
+                    statusCode = apiException.StatusCode;
                     context.Response.StatusCode = (int)statusCode;
                     logger.LogInformation(ex,
                         "ApiException caught by ApiExceptionHandler with  {statusCodeInt} {statusCodeString}. Unexpected: {unexpected}", (int)statusCode, statusCode.ToString(), false);
+                    break;
+                case OperationCanceledException _:
+                    errorCode = -1;
+                    statusCode = HttpStatusCode.InternalServerError;
+                    context.Response.StatusCode = (int)statusCode;
+                    logger.LogWarning(ex,
+                        "OperationCanceledException exception caught by ApiExceptionHandler. Will return with {statusCodeInt} {statusCodeString}. Unexpected: {unexpected}",
+                        (int)statusCode, statusCode.ToString(), true);
                     break;
                 default:
                     errorCode = -1;

--- a/test/aspnetcore-exceptionhandler-test/TestExceptionFilter.cs
+++ b/test/aspnetcore-exceptionhandler-test/TestExceptionFilter.cs
@@ -201,5 +201,21 @@ namespace Frogvall.AspNetCore.ExceptionHandling.Test
             ((JObject)error.DeveloperContext).ToObject<TestDeveloperContext>().TestContext.Should().Be(expectedContext);
             error.Service.Should().Be(expectedServiceName);
         }
+
+        [Fact]
+        public async Task GetCancellationTest_Always_ReturnsFault()
+        {
+            //Arrange
+
+            // Act
+            var response = await _client.GetAsync("/api/Test/Cancellation");
+            var error = JsonConvert.DeserializeObject<ApiError>(await response.Content.ReadAsStringAsync());
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+            error.ErrorCode.Should().Be(-1);
+            error.Service.Should().Be(Assembly.GetEntryAssembly().GetName().Name);
+            error.DeveloperContext.Should().BeNull();
+        }
     }
 }

--- a/test/aspnetcore-exceptionhandler-test/TestExceptionHandler.cs
+++ b/test/aspnetcore-exceptionhandler-test/TestExceptionHandler.cs
@@ -195,5 +195,21 @@ namespace Frogvall.AspNetCore.ExceptionHandling.Test
             ((JObject)error.DeveloperContext).ToObject<TestDeveloperContext>().TestContext.Should().Be(expectedContext);
             error.Service.Should().Be(expectedServiceName);
         }
+
+        [Fact]
+        public async Task GetCancellationTest_Always_ReturnsFault()
+        {
+            //Arrange
+
+            // Act
+            var response = await _client.GetAsync("/api/Test/Cancellation");
+            var error = JsonConvert.DeserializeObject<ApiError>(await response.Content.ReadAsStringAsync());
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+            error.ErrorCode.Should().Be(-1);
+            error.Service.Should().Be(TestServiceName);
+            error.DeveloperContext.Should().BeNull();
+        }
     }
 }

--- a/test/aspnetcore-exceptionhandler-test/TestResources/TestController.cs
+++ b/test/aspnetcore-exceptionhandler-test/TestResources/TestController.cs
@@ -45,7 +45,6 @@ namespace Frogvall.AspNetCore.ExceptionHandling.Test.TestResources
         }
 
         [HttpGet("Cancellation")]
-        [SkipModelValidationFilter]
         public IActionResult Cancellation()
         {
             throw new OperationCanceledException();

--- a/test/aspnetcore-exceptionhandler-test/TestResources/TestController.cs
+++ b/test/aspnetcore-exceptionhandler-test/TestResources/TestController.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using Frogvall.AspNetCore.ExceptionHandling.Attributes;
 using Frogvall.AspNetCore.ExceptionHandling.Exceptions;
 using Microsoft.AspNetCore.Mvc;
@@ -41,6 +42,13 @@ namespace Frogvall.AspNetCore.ExceptionHandling.Test.TestResources
         public IActionResult PostTestNoValidation([FromBody] TestDto testDto)
         {
             return Ok();
+        }
+
+        [HttpGet("Cancellation")]
+        [SkipModelValidationFilter]
+        public IActionResult Cancellation()
+        {
+            throw new OperationCanceledException();
         }
     }
 }


### PR DESCRIPTION
Added a special case for OperationCanceledException in the ApiErrorFactory. Now they should be logged as warns instead of errors.