### PR TITLE
Net5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   ci-executor:
     docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:5.0
+      - image: mcr.microsoft.com/dotnet/sdk:5.0
     working_directory: ~/Frogvall/aspnetcore-exceptionhandler
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   ci-executor:
     docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:3.1
+      - image: mcr.microsoft.com/dotnet/core/sdk:5.0
     working_directory: ~/Frogvall/aspnetcore-exceptionhandler
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Or add it to your csproj file.
 ```xml
 <ItemGroup>
         ...
-        <PackageReference Include="Frogvall.AspNetCore.ExceptionHandling" Version="5.0.0" />
+        <PackageReference Include="Frogvall.AspNetCore.ExceptionHandling" Version="6.0.0" />
         ...
 </ItemGroup>
 ```
@@ -146,7 +146,7 @@ When initializing the exception mapper, there are some options you can pass in. 
 
 ## Api error
 
-The exception handler uses an `ApiError` class that is serialized into the response body. There are also a couple of extension methods that can be used to parse an ApiError received as the response body from a downstream service.
+The exception handler uses an `ApiError` record that is serialized into the response body. There are also a couple of extension methods that can be used to parse an ApiError received as the response body from a downstream service.
 
 To parse an ApiError in an asynchronous context, use the `ParseApiErrorAsync` extension method.
 
@@ -191,7 +191,7 @@ or
 ```xml
 <ItemGroup>
         ...
-        <PackageReference Include="Frogvall.AspNetCore.ExceptionHandling.ModelValidation" Version="5.0.0" />
+        <PackageReference Include="Frogvall.AspNetCore.ExceptionHandling.ModelValidation" Version="6.0.0" />
         ...
 </ItemGroup>
 ```
@@ -234,7 +234,7 @@ or
 ```xml
 <ItemGroup>
         ...
-        <PackageReference Include="Frogvall.AspNetCore.ExceptionHandling.NewtonsoftJson" Version="5.0.0" />
+        <PackageReference Include="Frogvall.AspNetCore.ExceptionHandling.NewtonsoftJson" Version="6.0.0" />
         ...
 </ItemGroup>
 ```
@@ -280,7 +280,7 @@ or
 ```xml
 <ItemGroup>
         ...
-        <PackageReference Include="Frogvall.AspNetCore.ExceptionHandling.Swagger" Version="5.0.0" />
+        <PackageReference Include="Frogvall.AspNetCore.ExceptionHandling.Swagger" Version="6.0.0" />
         ...
 </ItemGroup>
 ```
@@ -308,7 +308,7 @@ or
 ```xml
 <ItemGroup>
         ...
-        <PackageReference Include="Frogvall.AspNetCore.ExceptionHandling.AwsXRay" Version="5.0.0" />
+        <PackageReference Include="Frogvall.AspNetCore.ExceptionHandling.AwsXRay" Version="6.0.0" />
         ...
 </ItemGroup>
 ```

--- a/src/aspnetcore-exceptionhandler-awsxray/aspnetcore-exceptionhandler-awsxray.csproj
+++ b/src/aspnetcore-exceptionhandler-awsxray/aspnetcore-exceptionhandler-awsxray.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>5.0.0</VersionPrefix>
+    <VersionPrefix>6.0.0</VersionPrefix>
     <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Frogvall.AspNetCore.ExceptionHandling</RootNamespace>
     <AssemblyName>ExceptionHandling.AwsXRay</AssemblyName>

--- a/src/aspnetcore-exceptionhandler-awsxray/aspnetcore-exceptionhandler-awsxray.csproj
+++ b/src/aspnetcore-exceptionhandler-awsxray/aspnetcore-exceptionhandler-awsxray.csproj
@@ -2,15 +2,14 @@
 
   <PropertyGroup>
     <VersionPrefix>5.0.0</VersionPrefix>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Frogvall.AspNetCore.ExceptionHandling</RootNamespace>
     <AssemblyName>ExceptionHandling.AwsXRay</AssemblyName>
     <PackageId>Frogvall.AspNetCore.ExceptionHandling.AwsXRay</PackageId>
-    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSXRayRecorder.Core" Version="2.6.2" />
+    <PackageReference Include="AWSXRayRecorder.Core" Version="2.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/aspnetcore-exceptionhandler-modelvalidation/aspnetcore-exceptionhandler-modelvalidation.csproj
+++ b/src/aspnetcore-exceptionhandler-modelvalidation/aspnetcore-exceptionhandler-modelvalidation.csproj
@@ -2,11 +2,10 @@
 
   <PropertyGroup>
     <VersionPrefix>5.0.0</VersionPrefix>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Frogvall.AspNetCore.ExceptionHandling</RootNamespace>
     <AssemblyName>ExceptionHandling.ModelValidation</AssemblyName>
     <PackageId>Frogvall.AspNetCore.ExceptionHandling.ModelValidation</PackageId>
-    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/aspnetcore-exceptionhandler-modelvalidation/aspnetcore-exceptionhandler-modelvalidation.csproj
+++ b/src/aspnetcore-exceptionhandler-modelvalidation/aspnetcore-exceptionhandler-modelvalidation.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>5.0.0</VersionPrefix>
+    <VersionPrefix>6.0.0</VersionPrefix>
     <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Frogvall.AspNetCore.ExceptionHandling</RootNamespace>
     <AssemblyName>ExceptionHandling.ModelValidation</AssemblyName>

--- a/src/aspnetcore-exceptionhandler-newtonsoftjson/aspnetcore-exceptionhandler-newtonsoftjson.csproj
+++ b/src/aspnetcore-exceptionhandler-newtonsoftjson/aspnetcore-exceptionhandler-newtonsoftjson.csproj
@@ -2,11 +2,10 @@
 
   <PropertyGroup>
     <VersionPrefix>5.0.0</VersionPrefix>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Frogvall.AspNetCore.ExceptionHandling</RootNamespace>
     <AssemblyName>ExceptionHandling.NewtonsoftJson</AssemblyName>
     <PackageId>Frogvall.AspNetCore.ExceptionHandling.NewtonsoftJson</PackageId>
-    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/aspnetcore-exceptionhandler-newtonsoftjson/aspnetcore-exceptionhandler-newtonsoftjson.csproj
+++ b/src/aspnetcore-exceptionhandler-newtonsoftjson/aspnetcore-exceptionhandler-newtonsoftjson.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>5.0.0</VersionPrefix>
+    <VersionPrefix>6.0.0</VersionPrefix>
     <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Frogvall.AspNetCore.ExceptionHandling</RootNamespace>
     <AssemblyName>ExceptionHandling.NewtonsoftJson</AssemblyName>

--- a/src/aspnetcore-exceptionhandler-swagger/aspnetcore-exceptionhandler-swagger.csproj
+++ b/src/aspnetcore-exceptionhandler-swagger/aspnetcore-exceptionhandler-swagger.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
   </ItemGroup>
 
 </Project>

--- a/src/aspnetcore-exceptionhandler-swagger/aspnetcore-exceptionhandler-swagger.csproj
+++ b/src/aspnetcore-exceptionhandler-swagger/aspnetcore-exceptionhandler-swagger.csproj
@@ -2,11 +2,10 @@
 
   <PropertyGroup>
     <VersionPrefix>5.0.0</VersionPrefix>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Frogvall.AspNetCore.ExceptionHandling</RootNamespace>
     <AssemblyName>ExceptionHandling.Swagger</AssemblyName>
     <PackageId>Frogvall.AspNetCore.ExceptionHandling.Swagger</PackageId>
-    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/aspnetcore-exceptionhandler-swagger/aspnetcore-exceptionhandler-swagger.csproj
+++ b/src/aspnetcore-exceptionhandler-swagger/aspnetcore-exceptionhandler-swagger.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>5.0.0</VersionPrefix>
+    <VersionPrefix>6.0.0</VersionPrefix>
     <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Frogvall.AspNetCore.ExceptionHandling</RootNamespace>
     <AssemblyName>ExceptionHandling.Swagger</AssemblyName>

--- a/src/aspnetcore-exceptionhandler/ExceptionHandling/ApiError.cs
+++ b/src/aspnetcore-exceptionhandler/ExceptionHandling/ApiError.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace Frogvall.AspNetCore.ExceptionHandling.ExceptionHandling
 {
-    public sealed class ApiError
+    public sealed record ApiError
     {
         public const string ModelBindingErrorMessage = "Invalid parameters.";
 

--- a/src/aspnetcore-exceptionhandler/ExceptionHandling/ApiErrorFactory.cs
+++ b/src/aspnetcore-exceptionhandler/ExceptionHandling/ApiErrorFactory.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Net;
 using System.Text.RegularExpressions;
-using AsyncFriendlyStackTrace;
 using Frogvall.AspNetCore.ExceptionHandling.Exceptions;
 using Frogvall.AspNetCore.ExceptionHandling.Mapper;
 using Microsoft.AspNetCore.Http;
@@ -84,7 +83,7 @@ namespace Frogvall.AspNetCore.ExceptionHandling.ExceptionHandling
             if (isDevelopment)
             {
                 error.Message = ex.Message;
-                error.DetailedMessage = ex.ToAsyncString();
+                error.DetailedMessage = ex.ToString();
             }
             else
             {

--- a/src/aspnetcore-exceptionhandler/aspnetcore-exceptionhandler.csproj
+++ b/src/aspnetcore-exceptionhandler/aspnetcore-exceptionhandler.csproj
@@ -2,11 +2,10 @@
 
   <PropertyGroup>
     <VersionPrefix>5.0.0</VersionPrefix>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Frogvall.AspNetCore.ExceptionHandling</RootNamespace>
     <AssemblyName>ExceptionHandling</AssemblyName>
     <PackageId>Frogvall.AspNetCore.ExceptionHandling</PackageId>
-    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/aspnetcore-exceptionhandler/aspnetcore-exceptionhandler.csproj
+++ b/src/aspnetcore-exceptionhandler/aspnetcore-exceptionhandler.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>5.0.0</VersionPrefix>
+    <VersionPrefix>6.0.0</VersionPrefix>
     <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Frogvall.AspNetCore.ExceptionHandling</RootNamespace>
     <AssemblyName>ExceptionHandling</AssemblyName>

--- a/src/aspnetcore-exceptionhandler/aspnetcore-exceptionhandler.csproj
+++ b/src/aspnetcore-exceptionhandler/aspnetcore-exceptionhandler.csproj
@@ -11,8 +11,4 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App"/>
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="AsyncFriendlyStackTrace" Version="1.6.0" />
-  </ItemGroup>
 </Project>

--- a/test/aspnet-core-exceptionhandler-test-mapping-profiles/aspnet-core-exceptionhandler-test-mapping-profiles.csproj
+++ b/test/aspnet-core-exceptionhandler-test-mapping-profiles/aspnet-core-exceptionhandler-test-mapping-profiles.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Frogvall.AspNetCore.ExceptionHandling.Test.MappingProfiles</RootNamespace>
   </PropertyGroup>
 

--- a/test/aspnetcore-exceptionhandler-test/aspnetcore-exceptionhandler-test.csproj
+++ b/test/aspnetcore-exceptionhandler-test/aspnetcore-exceptionhandler-test.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Frogvall.AspNetCore.ExceptionHandling.Test</RootNamespace>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="5.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Moq" Version="4.15.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="XunitXml.TestLogger" Version="2.1.26" />
   </ItemGroup>

--- a/test/aspnetcore-exceptionhandler-test/aspnetcore-exceptionhandler-test.csproj
+++ b/test/aspnetcore-exceptionhandler-test/aspnetcore-exceptionhandler-test.csproj
@@ -8,10 +8,10 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="5.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="5.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="Moq" Version="4.15.2" />
+    <PackageReference Include="Moq" Version="4.16.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="XunitXml.TestLogger" Version="2.1.26" />


### PR DESCRIPTION
Migrate to .net 5. ApiError is turned into a Record and the AsyncFriendlyStacktrace dependency that seems unmaintained is removed.